### PR TITLE
Use correct capacity estimator function

### DIFF
--- a/src/Peer.java
+++ b/src/Peer.java
@@ -223,7 +223,7 @@ public class Peer implements CDProtocol, EDProtocol
 		int localSetSize = localSet.size();
 		int remoteSetSize = remoteSet.size();
 		// TODO: Q could be dynamicly updated after each reconciliation.
-		int capacity = Math.abs(localSetSize - remoteSetSize) + (int)(defaultQ * (localSetSize + remoteSetSize)) + 1;
+		int capacity = Math.abs(localSetSize - remoteSetSize) + (int)(defaultQ * Math.min(localSetSize, remoteSetSize)) + 1;
 		if (capacity > diff) {
 			// Reconciliation succeeded right away.
 			successRecons++;


### PR DESCRIPTION
The estimator function used in the simulation is different to the one described in the Erlay paper and the one used in the [Bitcoin Core PR](https://github.com/bitcoin/bitcoin/pull/21515).

`capacity=|set_size - local_set_size| + q * (set_size + local_set_size) + 1` (currently used in the sim)
vs.
`capacity=|set_size - local_set_size| + q * min(set_size, local_set_size) + 1` (From the paper)

I am not sure how much this affects the results of the simulation, but the current function does overestimate when compared to the `min` version.

(i did not test this code change)