### PR TITLE
make reconciliation node percentage configurable

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -52,7 +52,7 @@ init.2.out_peers 8
 init.2.reachable_count 1500
 init.2.in_flood_delay 2000
 init.2.out_flood_delay 1000
-init.2.all_reconcile true
+init.2.reconciliation_percent 20
 init.2.reconciliation_interval 1000
 init.2.in_flood_peers_percent 10
 init.2.out_flood_peers_percent 10


### PR DESCRIPTION
I think it's important to simulate the network that's at {10, 50, 80, etc}% Erlay usage; it's not as realistic to think of it as "all or nothing." I was tinkering with the code to try to see how it worked anyway, so I figured I'd implement this. 

Peers will be initialized with `reconcile=true` with probability `init.2.reconciliation_percent/100`, and reconciliation will only happen when both peers have `reconcile=true`.